### PR TITLE
#13 Switch to licence expression instead of url

### DIFF
--- a/Package-signed.nuspec
+++ b/Package-signed.nuspec
@@ -5,7 +5,7 @@
     <version>1.0.2</version>
     <authors>Darren Kopp</authors>
     <owners>Darren Kopp, Ian Campbell</owners>
-    <licenseUrl>https://github.com/darrenkopp/murmurhash-net/blob/master/LICENSE.md</licenseUrl>
+	  <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/darrenkopp/murmurhash-net</projectUrl>
     <!--<iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>-->
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -5,7 +5,7 @@
     <version>1.0.2</version>
     <authors>Darren Kopp</authors>
     <owners>Darren Kopp, Ian Campbell</owners>
-    <licenseUrl>https://github.com/darrenkopp/murmurhash-net/blob/master/LICENSE.md</licenseUrl>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/darrenkopp/murmurhash-net</projectUrl>
     <!--<iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>-->
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
This will enable the licence type to be correctly rendered in nuget

Fixes: #13 